### PR TITLE
Fix for launchpad bug : 1324814

### DIFF
--- a/java_api.py
+++ b/java_api.py
@@ -374,9 +374,11 @@ public void set%(caml)s(%(type)s %(field)s) {
     public void clear%(caml)s() {
         if (%(field)s_refs != null) {
             %(field)s_refs.clear();
+            %(field)s_refs = new ArrayList<ObjectReference<%(datatype)s>>();
             return;
         }
         %(field)s_refs = null;
+        %(field)s_refs = new ArrayList<ObjectReference<%(datatype)s>>();
     }
 
 """ % {'caml': link_to.getCppName(), 'linktype': link_to.getCppName(),
@@ -396,6 +398,7 @@ public void set%(caml)s(%(type)s %(field)s) {
     }
     public void clear%(caml)s() {
         %(field)s_refs = null;
+        %(field)s_refs = new ArrayList<ObjectReference<ApiPropertyBase>>();
     }
 """ % {'caml': link_to.getCppName(), 'linktype': link_to.getCppName(),
        'field': link_to.getCIdentifierName()}


### PR DESCRIPTION
The java API has an issue with distinguishing between a field that is not set and something that has been explicitly cleared. This issue is coming up in the context of a delete operation that needs to clear a reference. If one uses the clear_X() method, the internal information is set to NULL and it results in no update being sent.

Fix for the same is committed. 